### PR TITLE
Ability to construct LazySeq from a Stream

### DIFF
--- a/src/main/java/com/nurkiewicz/lazyseq/LazySeq.java
+++ b/src/main/java/com/nurkiewicz/lazyseq/LazySeq.java
@@ -53,6 +53,10 @@ public abstract class LazySeq<E> extends AbstractList<E> {
 		return of(Arrays.asList(elements).iterator());
 	}
 
+	public static <E> LazySeq<E> of(Stream<E> elements) {
+		return of(elements.iterator());
+	}
+
 	public static <E> LazySeq<E> of(Iterable<E> elements) {
 		return of(elements.iterator());
 	}


### PR DESCRIPTION
A `Stream` is not an `Iterable`, even though it has a method `iterator()`. So I think this would be a nice additional method to have. Please let me know if there are better ways to construct a `LazySeq` from a `Stream` and have a strong opinion about this 😄 